### PR TITLE
Update index.html

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -9,7 +9,7 @@
   <!-- Font Awesome -->
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
   <!-- Bootstrap core CSS -->
-  {% load staticfiles %}
+{% load static %}
   <link href="{% static 'css/bootstrap.min.css' %}" rel="stylesheet">
   <!-- Material Design Bootstrap -->
   <link href="{% static 'css/mdb.min.css' %}" rel="stylesheet">


### PR DESCRIPTION
In Django 3.x versions, the staticfiles and admin_static tag libraries have been deprecated and replaced by static and admin_static, respectively.